### PR TITLE
Template expressions lose their ${} 

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -137,7 +137,7 @@
       "const port = 3000",
       "",
       "app.get('/', (req, res) => res.send('Hello World!'))",
-      "app.listen(port, () => console.log(`Example app listening on port ${port}!`))"
+      "app.listen(port, () => console.log(`Example app listening on port \\${port\\}!`))"
     ],
     "description": "Creates an express server"
   },
@@ -176,7 +176,7 @@
       "",
       "app.post('/update', function(req, res) {",
       "  const { name, description } = req.body;",
-      "  res.send(`Name ${name}, desc ${description}`);",
+      "  res.send(`Name \\${name\\}, desc \\${description\\}`);",
       "});"
     ],
     "description": "Creates a POST route that can read from the body"
@@ -189,7 +189,7 @@
       "",
       "app.put('/products', function(req, res) {",
       "  const { id, name, description } = req.body;",
-      "  res.send(`Name ${id} ${name}, desc ${description}`);",
+      "  res.send(`Name \\${id\\} \\${name\\}, desc \\${description\\}`);",
       "});"
     ],
     "description": "Creates a POST route that can read from the body"
@@ -202,7 +202,7 @@
       "",
       "app.delete('/products/:id', function(req, res) {",
       "  const { id } = req.params;",
-      "  res.send(`Delete record with id ${id}`);",
+      "  res.send(`Delete record with id \\${id\\}`);",
       "});"
     ],
     "description": "Creates a POST route that can read from the body"
@@ -217,7 +217,7 @@
       "app.get('/products', function(req, res) {",
       "  const page = req.query.page;",
       "  const pageSize = req.query.pageSize;",
-      "  res.send(`Filter with parameters ${page} and ${pageSize});`",
+      "  res.send(`Filter with parameters \\${page\\} and \\${pageSize\\});`",
       "});"
     ],
     "description": "Creates a POST route that can read from the body"
@@ -355,7 +355,7 @@
       "function getAll() {",
       "  const data = await getData();",
       "  const moreData = await getMoreData(data);",
-      "  return `All the data: ${data}, ${moreData}`;",
+      "  return `All the data: \\${data\\}, \\${moreData\\}`;",
       "}",
       "",
       "getAll().then((all) => {",
@@ -406,11 +406,7 @@
   },
   "supertest-beforeall": {
     "prefix": "node-supertest-beforeall",
-    "body": [
-      "beforeAll(() => {",
-      "  request = supertest(app)",
-      "})"
-    ],
+    "body": ["beforeAll(() => {", "  request = supertest(app)", "})"],
     "description": "Configures supertest to use the app, this is needed"
   },
   "supertest-afterall": {
@@ -490,8 +486,8 @@
       "    name: 'book3',",
       "  }",
       " ];",
-     "  expect(newRes.body).toEqual(products);",
-     "});"
+      "  expect(newRes.body).toEqual(products);",
+      "});"
     ],
     "description": "An example of supertest testing a POST route with a payload"
   }


### PR DESCRIPTION
This is to address issue #1 .

I'm not sure if we can do something to fix the fact that those characters in the snippets are ignored since this is probably handled within the core of VS Code. However, we can escape those characters using "\".

So I corrected the snippets.json which generates a snippet with interpreted strings in it. Adding "\\" will prevent VS Code from interpreting the specials characters like "$", "{" and "}" . This way, those characters aren't discarded by VS Code once the rendering of the snippet is done.