### PR TITLE
Refactor: Replace var with const for improved scoping

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -171,7 +171,7 @@
   "express POST params": {
     "prefix": "node-express-post-params",
     "body": [
-      "var bodyParser = require('body-parser');",
+      "const bodyParser = require('body-parser');",
       "app.use(bodyParser.json());",
       "",
       "app.post('/update', function(req, res) {",
@@ -184,7 +184,7 @@
   "express PUT params": {
     "prefix": "node-express-put-params",
     "body": [
-      "var bodyParser = require('body-parser');",
+      "const bodyParser = require('body-parser');",
       "app.use(bodyParser.json());",
       "",
       "app.put('/products', function(req, res) {",
@@ -197,7 +197,7 @@
   "express DELETE params": {
     "prefix": "node-express-delete-params",
     "body": [
-      "var bodyParser = require('body-parser');",
+      "const bodyParser = require('body-parser');",
       "app.use(bodyParser.json());",
       "",
       "app.delete('/products/:id', function(req, res) {",
@@ -210,7 +210,7 @@
   "express QUERY params": {
     "prefix": "node-express-query-params",
     "body": [
-      "var bodyParser = require('body-parser');",
+      "const bodyParser = require('body-parser');",
       "app.use(bodyParser.json());",
       "",
       "// for routes looking like this `/products?page=1&pageSize=50`",
@@ -263,7 +263,7 @@
   "http server": {
     "prefix": "node-http-server",
     "body": [
-      "var http = require('http');",
+      "const http = require('http');",
       "http.createServer(function (request, response) {",
       "  response.writeHead(200, {'Content-Type': 'text/plain'});",
       "  response.end('Hello World');",
@@ -276,15 +276,15 @@
   "file read sync": {
     "prefix": "node-file-read-sync",
     "body": [
-      "var fs = require('fs');",
-      "var data = fs.readFileSync('file.txt');"
+      "const fs = require('fs');",
+      "const data = fs.readFileSync('file.txt');"
     ],
     "description": "Reads a file synchronously"
   },
   "file read async": {
     "prefix": "node-file-read-async",
     "body": [
-      "var fs = require('fs');",
+      "const fs = require('fs');",
       "fs.readFile('input.txt', function (err, data) {",
       "  if (err) return console.error(err);",
       "  console.log(data.toString());",
@@ -295,8 +295,8 @@
   "event emitter": {
     "prefix": "node-event-emitter",
     "body": [
-      "var events = require('events');",
-      "var eventEmitter = new events.EventEmitter();",
+      "const events = require('events');",
+      "const eventEmitter = new events.EventEmitter();",
       "eventEmitter.emit('my_event');",
       "eventEmitter.on('my_event', () => {",
       "  console.log('data received successfully.');",


### PR DESCRIPTION
This pull request replaces all instances of `var` with `const` in the codebase. This change improves the scoping of variables, as `const` is block-scoped while `var` is function-scoped. This can help prevent accidental redeclaration or overwriting of variables, and makes the code more predictable and easier to maintain.